### PR TITLE
Remove unnecessary dependency on the Vulkan cmake package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ if (VULKAN_SDK)
     set(ENV{VULKAN_SDK} ${VULKAN_SDK})
 endif()
 
-find_package(Vulkan REQUIRED)
 find_package(vsg 0.1.6 REQUIRED)
 
 # find the optional vsgXchange that can be used for reading and range of image and 3d model formats and shader compilation


### PR DESCRIPTION
The vsg cmake package already provides this dependency.

See vsg-dev/VulkanSceneGraph#312