### PR TITLE
Add flag to prevent calling uploadFonts() in constructor

### DIFF
--- a/include/vsgImGui/RenderImGui.h
+++ b/include/vsgImGui/RenderImGui.h
@@ -38,7 +38,7 @@ namespace vsgImGui
     class VSGIMGUI_DECLSPEC RenderImGui : public vsg::Inherit<vsg::Command, RenderImGui>
     {
     public:
-        RenderImGui(const vsg::ref_ptr<vsg::Window>& window, bool useClearAttachments = false);
+        RenderImGui(const vsg::ref_ptr<vsg::Window>& window, bool useClearAttachments = false, bool uploadFonts = true);
 
         template<typename... Args>
         RenderImGui(const vsg::ref_ptr<vsg::Window>& window, Args&... args) :

--- a/src/vsgImGui/RenderImGui.cpp
+++ b/src/vsgImGui/RenderImGui.cpp
@@ -40,10 +40,10 @@ namespace
     }
 } // namespace
 
-RenderImGui::RenderImGui(const vsg::ref_ptr<vsg::Window>& window, bool useClearAttachments)
+RenderImGui::RenderImGui(const vsg::ref_ptr<vsg::Window>& window, bool useClearAttachments, bool uploadFonts)
 {
     _init(window);
-    _uploadFonts();
+    if(uploadFonts) _uploadFonts();
 
     if (useClearAttachments)
     {


### PR DESCRIPTION
Add flag to prevent calling uploadFonts() in constructor in case you want to add your own fonts.

Note that _uploadFonts() was moved to public: so that it could be called after initialising custom fonts. This is not part of the PR.

You need to call _uploadFonts() after initialising custom fonts, and you need to have already created RenderImGui before initialising your custom fonts because it needs to call ImGui::GetIO(). However, RenderImGui calls _uploadFonts() in it's constructor. Calling _uploadFonts() twice results in several Vulkan resources not being deleted and generates validation errors when the application exists.

Adding an option to prevent the RenderImGui constructor calling _uploadFonts(), then calling it manually after initialising custom fonts works and prevents errors. There may be better ways to do this, but it demonstrates the problem.