### PR TITLE
Keyboard

### DIFF
--- a/src/vsgImGui/SendEventsToImGui.cpp
+++ b/src/vsgImGui/SendEventsToImGui.cpp
@@ -103,8 +103,8 @@ uint16_t SendEventsToImGui::_mapToSpecialKey(const vsg::KeyEvent& keyEvent) cons
     auto itr = _vsgToIntermediateMap.find(keyAndModifier);
     uint16_t special_key = (itr != _vsgToIntermediateMap.end()) ? itr->second : 0;
 
-    assert(special_key < 512 && "ImGui KeysDown is an array of 512");
-    assert(special_key > 256 && "ASCII stop at 127, but we use the range [257, 511]");
+    // assert(special_key < 512 && "ImGui KeysDown is an array of 512");
+    // assert(special_key > 256 && "ASCII stop at 127, but we use the range [257, 511]");
 
     return special_key;
 }

--- a/src/vsgImGui/SendEventsToImGui.cpp
+++ b/src/vsgImGui/SendEventsToImGui.cpp
@@ -204,8 +204,8 @@ void SendEventsToImGui::apply(vsg::KeyReleaseEvent& keyRelease)
 
     // Imgui input controls loose focus when enter is pressed, so io.WantCaptureKeyboard = false. We need to test for this condition and process the Enter/KP_Enter release
     if (io.WantCaptureKeyboard
-        || (io.KeysDown[270] == true && keyRelease.keyBase == vsg::KeySymbol::KEY_Return)
-        || (io.KeysDown[270] == true && keyRelease.keyBase == vsg::KeySymbol::KEY_KP_Enter) )
+        || (io.KeysDown[269] == true && keyRelease.keyBase == vsg::KeySymbol::KEY_Return)
+        || (io.KeysDown[269] == true && keyRelease.keyBase == vsg::KeySymbol::KEY_KP_Enter) )
     {
         if (keyRelease.keyBase == vsg::KeySymbol::KEY_KP_Enter) keyRelease.keyModified = vsg::KeySymbol::KEY_Return;
 

--- a/src/vsgImGui/SendEventsToImGui.cpp
+++ b/src/vsgImGui/SendEventsToImGui.cpp
@@ -220,8 +220,8 @@ void SendEventsToImGui::apply(vsg::KeyReleaseEvent& keyRelease)
         }
         else if (uint16_t c = keyRelease.keyModified; c > 0)
         {
-            // Translate numpad numbers into normal numbers
-            if (c >= 65450 && c <= 65465) c = c - 65408;
+            // Translate numpad numbers plus related keys (*/+-) into normal numbers and keys
+            if (c >= vsg::KEY_KP_Multiply && c <= vsg::KEY_KP_9) c = c - (vsg::KEY_KP_Multiply - vsg::KEY_Asterisk);
             if (c < 512) io.KeysDown[c] = false;
         }
 


### PR DESCRIPTION
This PR fixes problems with:
- numpad keys not working, crashing vsgImgui or generating assert failures. 
- ImGui controls losing focus when Enter is pressed.
- Recent change for Enter code from 270 to 269

Tested on Kubuntu 22.04

