### PR TITLE
WIP Map vsg to ImGui keys. Change key events to io.AddKeyEvent()

### DIFF
--- a/include/vsgImGui/SendEventsToImGui.h
+++ b/include/vsgImGui/SendEventsToImGui.h
@@ -50,16 +50,16 @@ namespace vsgImGui
         ~SendEventsToImGui();
 
         uint32_t _convertButton(uint32_t button);
-        void _assignKeyMapping(uint16_t imGuiKey, vsg::KeySymbol vsgKey, vsg::KeyModifier vsgModifier = {});
-        void _assignKeyMapping(uint16_t imGuiKey, vsg::KeySymbol vsgKey, vsg::KeySymbol vsgKeyAlternate, vsg::KeyModifier vsgModifier = {});
+        // void _assignKeyMapping(uint16_t imGuiKey, vsg::KeySymbol vsgKey, vsg::KeyModifier vsgModifier = {});
+        // void _assignKeyMapping(uint16_t imGuiKey, vsg::KeySymbol vsgKey, vsg::KeySymbol vsgKeyAlternate, vsg::KeyModifier vsgModifier = {});
         void _initKeymap();
-        uint16_t _mapToSpecialKey(const vsg::KeyEvent& keyEvent) const;
+        // uint16_t _mapToSpecialKey(const vsg::KeyEvent& keyEvent) const;
 
         std::chrono::high_resolution_clock::time_point t0;
         bool _dragging;
 
         using KeyAndModifier = std::pair<vsg::KeySymbol, vsg::KeyModifier>;
-        std::map<KeyAndModifier, uint16_t> _vsgToIntermediateMap;
+        std::map<vsg::KeySymbol, ImGuiKey> _vsgToImGuiKeyMap;
     };
 } // namespace vsgImGui
 

--- a/src/vsgImGui/SendEventsToImGui.cpp
+++ b/src/vsgImGui/SendEventsToImGui.cpp
@@ -49,66 +49,6 @@ uint32_t SendEventsToImGui::_convertButton(uint32_t button)
     return button == 1 ? 0 : button == 3 ? 1 : button;
 }
 
-void SendEventsToImGui::_assignKeyMapping(uint16_t imGuiKey, vsg::KeySymbol vsgKey, vsg::KeyModifier vsgModifier)
-{
-    ImGuiIO& io = ImGui::GetIO();
-
-    uint16_t mappedKey = 257 + _vsgToIntermediateMap.size();
-    _vsgToIntermediateMap[KeyAndModifier(vsgKey, vsgModifier)] = mappedKey;
-
-    io.KeyMap[imGuiKey] = mappedKey;
-}
-
-void SendEventsToImGui::_assignKeyMapping(uint16_t imGuiKey, vsg::KeySymbol vsgKey, vsg::KeySymbol vsgKeyAlternate, vsg::KeyModifier vsgModifier)
-{
-    ImGuiIO& io = ImGui::GetIO();
-
-    uint16_t mappedKey = 257 + _vsgToIntermediateMap.size();
-    _vsgToIntermediateMap[KeyAndModifier(vsgKey, vsgModifier)] = mappedKey;
-    _vsgToIntermediateMap[KeyAndModifier(vsgKeyAlternate, vsgModifier)] = mappedKey;
-
-    io.KeyMap[imGuiKey] = mappedKey;
-}
-
-void SendEventsToImGui::_initKeymap()
-{
-    // Keyboard mapping. ImGui will use those indices to peek into the
-    // io.KeyDown[] array.
-    _assignKeyMapping(ImGuiKey_Tab, vsg::KeySymbol::KEY_Tab);
-    _assignKeyMapping(ImGuiKey_LeftArrow, vsg::KeySymbol::KEY_Left);
-    _assignKeyMapping(ImGuiKey_RightArrow, vsg::KeySymbol::KEY_Right);
-    _assignKeyMapping(ImGuiKey_UpArrow, vsg::KeySymbol::KEY_Up);
-    _assignKeyMapping(ImGuiKey_DownArrow, vsg::KeySymbol::KEY_Down);
-    _assignKeyMapping(ImGuiKey_PageUp, vsg::KeySymbol::KEY_Page_Up);
-    _assignKeyMapping(ImGuiKey_PageDown, vsg::KeySymbol::KEY_Page_Down);
-    _assignKeyMapping(ImGuiKey_Home, vsg::KeySymbol::KEY_Home);
-    _assignKeyMapping(ImGuiKey_End, vsg::KeySymbol::KEY_End);
-    _assignKeyMapping(ImGuiKey_Insert, vsg::KeySymbol::KEY_Insert);
-    _assignKeyMapping(ImGuiKey_Delete, vsg::KeySymbol::KEY_Delete);
-    _assignKeyMapping(ImGuiKey_Backspace, vsg::KeySymbol::KEY_BackSpace);
-    _assignKeyMapping(ImGuiKey_Enter, vsg::KeySymbol::KEY_Return);
-    _assignKeyMapping(ImGuiKey_Escape, vsg::KeySymbol::KEY_Escape);
-    _assignKeyMapping(ImGuiKey_KeyPadEnter, vsg::KeySymbol::KEY_KP_Enter);
-    _assignKeyMapping(ImGuiKey_A, vsg::KeySymbol::KEY_A, vsg::KeySymbol::KEY_a, vsg::KeyModifier::MODKEY_Control);
-    _assignKeyMapping(ImGuiKey_C, vsg::KeySymbol::KEY_C, vsg::KeySymbol::KEY_c, vsg::KeyModifier::MODKEY_Control);
-    _assignKeyMapping(ImGuiKey_V, vsg::KeySymbol::KEY_V, vsg::KeySymbol::KEY_v, vsg::KeyModifier::MODKEY_Control);
-    _assignKeyMapping(ImGuiKey_X, vsg::KeySymbol::KEY_X, vsg::KeySymbol::KEY_x, vsg::KeyModifier::MODKEY_Control);
-    _assignKeyMapping(ImGuiKey_Y, vsg::KeySymbol::KEY_Y, vsg::KeySymbol::KEY_y, vsg::KeyModifier::MODKEY_Control);
-    _assignKeyMapping(ImGuiKey_Z, vsg::KeySymbol::KEY_Z, vsg::KeySymbol::KEY_z, vsg::KeyModifier::MODKEY_Control);
-}
-
-uint16_t SendEventsToImGui::_mapToSpecialKey(const vsg::KeyEvent& keyEvent) const
-{
-    KeyAndModifier keyAndModifier(keyEvent.keyModified, vsg::KeyModifier(keyEvent.keyModifier & vsg::KeyModifier::MODKEY_Control));
-    auto itr = _vsgToIntermediateMap.find(keyAndModifier);
-    uint16_t special_key = (itr != _vsgToIntermediateMap.end()) ? itr->second : 0;
-
-    assert(special_key < 512 && "ImGui KeysDown is an array of 512");
-    assert(special_key > 256 && "ASCII stop at 127, but we use the range [257, 511]");
-
-    return special_key;
-}
-
 void SendEventsToImGui::apply(vsg::ButtonPressEvent& buttonPress)
 {
     ImGuiIO& io = ImGui::GetIO();
@@ -177,15 +117,8 @@ void SendEventsToImGui::apply(vsg::KeyPressEvent& keyPress)
         io.KeyAlt = (keyPress.keyModifier & vsg::KeyModifier::MODKEY_Alt) != 0;
         io.KeySuper = (keyPress.keyModifier & vsg::KeyModifier::MODKEY_Meta) != 0;
 
-        if (uint16_t special_key = _mapToSpecialKey(keyPress); special_key > 0)
-        {
-            io.KeysDown[special_key] = true;
-        }
-        else if (uint16_t c = keyPress.keyModified; c > 0)
-        {
-            if (c < 512) io.KeysDown[c] = true;
-            io.AddInputCharacter((unsigned short)c);
-        }
+        auto imguiKey = _vsgToImGuiKeyMap[keyPress.keyBase]; 
+        io.AddKeyEvent(imguiKey, true);
 
         keyPress.handled = true;
     }
@@ -202,14 +135,8 @@ void SendEventsToImGui::apply(vsg::KeyReleaseEvent& keyRelease)
         io.KeyAlt = (keyRelease.keyModifier & vsg::KeyModifier::MODKEY_Alt) != 0;
         io.KeySuper = (keyRelease.keyModifier & vsg::KeyModifier::MODKEY_Meta) != 0;
 
-        if (uint16_t special_key = _mapToSpecialKey(keyRelease); special_key > 0)
-        {
-            io.KeysDown[special_key] = false;
-        }
-        else if (uint16_t c = keyRelease.keyModified; c > 0)
-        {
-            if (c < 512) io.KeysDown[c] = false;
-        }
+        auto imguiKey = _vsgToImGuiKeyMap[keyRelease.keyBase]; 
+        io.AddKeyEvent(imguiKey, false);
 
         keyRelease.handled = true;
     }
@@ -232,3 +159,114 @@ void SendEventsToImGui::apply(vsg::FrameEvent& /*frame*/)
 
     io.DeltaTime = dt;
 }
+
+void SendEventsToImGui::_initKeymap()
+{
+    _vsgToImGuiKeyMap[vsg::KEY_Undefined] = ImGuiKey_None;
+    _vsgToImGuiKeyMap[vsg::KEY_Space] = ImGuiKey_Space;
+    _vsgToImGuiKeyMap[vsg::KEY_0] = ImGuiKey_0;
+    _vsgToImGuiKeyMap[vsg::KEY_1] = ImGuiKey_1;
+    _vsgToImGuiKeyMap[vsg::KEY_2] = ImGuiKey_2;
+    _vsgToImGuiKeyMap[vsg::KEY_3] = ImGuiKey_3;
+    _vsgToImGuiKeyMap[vsg::KEY_4] = ImGuiKey_4;
+    _vsgToImGuiKeyMap[vsg::KEY_5] = ImGuiKey_5;
+    _vsgToImGuiKeyMap[vsg::KEY_6] = ImGuiKey_6;
+    _vsgToImGuiKeyMap[vsg::KEY_7] = ImGuiKey_7;
+    _vsgToImGuiKeyMap[vsg::KEY_8] = ImGuiKey_8;
+    _vsgToImGuiKeyMap[vsg::KEY_9] = ImGuiKey_9;
+    _vsgToImGuiKeyMap[vsg::KEY_a] = ImGuiKey_A;
+    _vsgToImGuiKeyMap[vsg::KEY_b] = ImGuiKey_B;
+    _vsgToImGuiKeyMap[vsg::KEY_c] = ImGuiKey_C;
+    _vsgToImGuiKeyMap[vsg::KEY_d] = ImGuiKey_D;
+    _vsgToImGuiKeyMap[vsg::KEY_e] = ImGuiKey_E;
+    _vsgToImGuiKeyMap[vsg::KEY_f] = ImGuiKey_F;
+    _vsgToImGuiKeyMap[vsg::KEY_g] = ImGuiKey_G;
+    _vsgToImGuiKeyMap[vsg::KEY_h] = ImGuiKey_H;
+    _vsgToImGuiKeyMap[vsg::KEY_i] = ImGuiKey_I;
+    _vsgToImGuiKeyMap[vsg::KEY_j] = ImGuiKey_J;
+    _vsgToImGuiKeyMap[vsg::KEY_k] = ImGuiKey_K;
+    _vsgToImGuiKeyMap[vsg::KEY_l] = ImGuiKey_L;
+    _vsgToImGuiKeyMap[vsg::KEY_m] = ImGuiKey_M;
+    _vsgToImGuiKeyMap[vsg::KEY_n] = ImGuiKey_N;
+    _vsgToImGuiKeyMap[vsg::KEY_o] = ImGuiKey_O;
+    _vsgToImGuiKeyMap[vsg::KEY_p] = ImGuiKey_P;
+    _vsgToImGuiKeyMap[vsg::KEY_q] = ImGuiKey_Q;
+    _vsgToImGuiKeyMap[vsg::KEY_r] = ImGuiKey_R;
+    _vsgToImGuiKeyMap[vsg::KEY_s] = ImGuiKey_S;
+    _vsgToImGuiKeyMap[vsg::KEY_t] = ImGuiKey_T;
+    _vsgToImGuiKeyMap[vsg::KEY_u] = ImGuiKey_U;
+    _vsgToImGuiKeyMap[vsg::KEY_v] = ImGuiKey_V;
+    _vsgToImGuiKeyMap[vsg::KEY_w] = ImGuiKey_W;
+    _vsgToImGuiKeyMap[vsg::KEY_x] = ImGuiKey_X;
+    _vsgToImGuiKeyMap[vsg::KEY_y] = ImGuiKey_Y;
+    _vsgToImGuiKeyMap[vsg::KEY_z] = ImGuiKey_Z;
+    _vsgToImGuiKeyMap[vsg::KEY_Quote] = ImGuiKey_Apostrophe;
+    _vsgToImGuiKeyMap[vsg::KEY_Leftparen] = ImGuiKey_LeftBracket;
+    _vsgToImGuiKeyMap[vsg::KEY_Rightparen] = ImGuiKey_RightBracket;
+    _vsgToImGuiKeyMap[vsg::KEY_Comma] = ImGuiKey_Comma;
+    _vsgToImGuiKeyMap[vsg::KEY_Minus] = ImGuiKey_Minus;
+    _vsgToImGuiKeyMap[vsg::KEY_Period] = ImGuiKey_Period;
+    _vsgToImGuiKeyMap[vsg::KEY_Slash] = ImGuiKey_Slash;
+    _vsgToImGuiKeyMap[vsg::KEY_Semicolon] = ImGuiKey_Semicolon;
+    _vsgToImGuiKeyMap[vsg::KEY_Equals] = ImGuiKey_Equal;
+    _vsgToImGuiKeyMap[vsg::KEY_Backslash] = ImGuiKey_Backslash;
+    _vsgToImGuiKeyMap[vsg::KEY_BackSpace] = ImGuiKey_Backspace;
+    _vsgToImGuiKeyMap[vsg::KEY_Tab] = ImGuiKey_Tab;
+    _vsgToImGuiKeyMap[vsg::KEY_Return] = ImGuiKey_Enter;
+    _vsgToImGuiKeyMap[vsg::KEY_Pause] = ImGuiKey_Pause;
+    _vsgToImGuiKeyMap[vsg::KEY_Scroll_Lock] = ImGuiKey_ScrollLock;
+    _vsgToImGuiKeyMap[vsg::KEY_Escape] = ImGuiKey_Escape;
+    _vsgToImGuiKeyMap[vsg::KEY_Delete] = ImGuiKey_Delete;
+    _vsgToImGuiKeyMap[vsg::KEY_Home] = ImGuiKey_Home;
+    _vsgToImGuiKeyMap[vsg::KEY_Left] = ImGuiKey_LeftArrow;
+    _vsgToImGuiKeyMap[vsg::KEY_Up] = ImGuiKey_UpArrow;
+    _vsgToImGuiKeyMap[vsg::KEY_Right] = ImGuiKey_RightArrow;
+    _vsgToImGuiKeyMap[vsg::KEY_Down] = ImGuiKey_DownArrow;
+    _vsgToImGuiKeyMap[vsg::KEY_Page_Up] = ImGuiKey_PageUp;
+    _vsgToImGuiKeyMap[vsg::KEY_Page_Down] = ImGuiKey_PageDown;
+    _vsgToImGuiKeyMap[vsg::KEY_End] = ImGuiKey_End;
+    _vsgToImGuiKeyMap[vsg::KEY_Print] = ImGuiKey_PrintScreen;
+    _vsgToImGuiKeyMap[vsg::KEY_Insert] = ImGuiKey_Insert;
+    _vsgToImGuiKeyMap[vsg::KEY_Num_Lock] = ImGuiKey_NumLock;
+    _vsgToImGuiKeyMap[vsg::KEY_KP_Enter] = ImGuiKey_KeypadEnter;
+    _vsgToImGuiKeyMap[vsg::KEY_KP_Equal] = ImGuiKey_KeypadEqual;
+    _vsgToImGuiKeyMap[vsg::KEY_KP_Multiply] = ImGuiKey_KeypadMultiply;
+    _vsgToImGuiKeyMap[vsg::KEY_KP_Add] = ImGuiKey_KeypadAdd;
+    _vsgToImGuiKeyMap[vsg::KEY_KP_Subtract] = ImGuiKey_KeypadSubtract;
+    _vsgToImGuiKeyMap[vsg::KEY_KP_Decimal] = ImGuiKey_KeypadDecimal;
+    _vsgToImGuiKeyMap[vsg::KEY_KP_Divide] = ImGuiKey_KeypadDivide;
+    _vsgToImGuiKeyMap[vsg::KEY_KP_0] = ImGuiKey_Keypad0;
+    _vsgToImGuiKeyMap[vsg::KEY_KP_1] = ImGuiKey_Keypad1;
+    _vsgToImGuiKeyMap[vsg::KEY_KP_2] = ImGuiKey_Keypad2;
+    _vsgToImGuiKeyMap[vsg::KEY_KP_3] = ImGuiKey_Keypad3;
+    _vsgToImGuiKeyMap[vsg::KEY_KP_4] = ImGuiKey_Keypad4;
+    _vsgToImGuiKeyMap[vsg::KEY_KP_5] = ImGuiKey_Keypad5;
+    _vsgToImGuiKeyMap[vsg::KEY_KP_6] = ImGuiKey_Keypad6;
+    _vsgToImGuiKeyMap[vsg::KEY_KP_7] = ImGuiKey_Keypad7;
+    _vsgToImGuiKeyMap[vsg::KEY_KP_8] = ImGuiKey_Keypad8;
+    _vsgToImGuiKeyMap[vsg::KEY_KP_9] = ImGuiKey_Keypad9;
+    _vsgToImGuiKeyMap[vsg::KEY_F1] = ImGuiKey_F1;
+    _vsgToImGuiKeyMap[vsg::KEY_F2] = ImGuiKey_F2;
+    _vsgToImGuiKeyMap[vsg::KEY_F3] = ImGuiKey_F3;
+    _vsgToImGuiKeyMap[vsg::KEY_F4] = ImGuiKey_F4;
+    _vsgToImGuiKeyMap[vsg::KEY_F5] = ImGuiKey_F5;
+    _vsgToImGuiKeyMap[vsg::KEY_F6] = ImGuiKey_F6;
+    _vsgToImGuiKeyMap[vsg::KEY_F7] = ImGuiKey_F7;
+    _vsgToImGuiKeyMap[vsg::KEY_F8] = ImGuiKey_F8;
+    _vsgToImGuiKeyMap[vsg::KEY_F9] = ImGuiKey_F9;
+    _vsgToImGuiKeyMap[vsg::KEY_F10] = ImGuiKey_F10;
+    _vsgToImGuiKeyMap[vsg::KEY_F11] = ImGuiKey_F11;
+    _vsgToImGuiKeyMap[vsg::KEY_F12] = ImGuiKey_F12;
+    _vsgToImGuiKeyMap[vsg::KEY_Shift_L] = ImGuiKey_LeftShift;
+    _vsgToImGuiKeyMap[vsg::KEY_Shift_R] = ImGuiKey_RightShift;
+    _vsgToImGuiKeyMap[vsg::KEY_Control_L] = ImGuiKey_LeftCtrl;
+    _vsgToImGuiKeyMap[vsg::KEY_Control_R] = ImGuiKey_RightCtrl;
+    _vsgToImGuiKeyMap[vsg::KEY_Caps_Lock] = ImGuiKey_CapsLock;
+    _vsgToImGuiKeyMap[vsg::KEY_Meta_L] = ImGuiKey_Menu;
+    _vsgToImGuiKeyMap[vsg::KEY_Meta_R] = ImGuiKey_Menu;
+    _vsgToImGuiKeyMap[vsg::KEY_Alt_L] = ImGuiKey_LeftAlt;
+    _vsgToImGuiKeyMap[vsg::KEY_Alt_R] = ImGuiKey_RightAlt;
+    _vsgToImGuiKeyMap[vsg::KEY_Super_L] = ImGuiKey_LeftSuper;
+    _vsgToImGuiKeyMap[vsg::KEY_Super_R] = ImGuiKey_RightSuper;
+}
+


### PR DESCRIPTION
The way ImGui handles keyboard input has changed around version 1.87 or 1.88. This draft PR builds and runs, but the key events don't appear to do anything within ImGui. I have:

- Built a new key translation map based on the new ImGui key codes
- Changed to using AddKeyEvent() to push the key code to ImGui.

The translation looks to be working OK and there are no errors, but the ImGui demo doesn't echo the characters in the text box.

A discussion of the changes is here
https://github.com/ocornut/imgui/issues/4921

The new way of handling keys looks to be much easier - maybe too easy and I haven't understood it. Could you also cast an eye over it.

Roland

