### PR TITLE
Allow RenderImGui to work without a vsg::Window

### DIFF
--- a/include/vsgImGui/RenderImGui.h
+++ b/include/vsgImGui/RenderImGui.h
@@ -40,10 +40,10 @@ namespace vsgImGui
     public:
         RenderImGui(const vsg::ref_ptr<vsg::Window>& window, bool useClearAttachments = false);
 
-        RenderImGui(vsg::ref_ptr<vsg::Device> device, uint32_t queueFamily,
-                   vsg::ref_ptr<vsg::RenderPass> renderPass,
+        RenderImGui(vsg::ref_ptr<vsg::Device> device, uint32_t queueFamily, 
+                   vsg::ref_ptr<vsg::RenderPass> renderPass, 
                    uint32_t minImageCount, uint32_t imageCount,
-                   VkExtent2D imageSize);
+                   VkExtent2D imageSize, bool useClearAttachments = false);
 
         template<typename... Args>
         RenderImGui(const vsg::ref_ptr<vsg::Window>& window, Args&... args) :
@@ -84,11 +84,11 @@ namespace vsgImGui
 
         vsg::ref_ptr<vsg::ClearAttachments> _clearAttachments;
 
-        void _init(const vsg::ref_ptr<vsg::Window>& window);
-        void _init(vsg::ref_ptr<vsg::Device> device, uint32_t queueFamily,
-                   vsg::ref_ptr<vsg::RenderPass> renderPass,
+        void _init(const vsg::ref_ptr<vsg::Window>& window, bool useClearAttachments);
+        void _init(vsg::ref_ptr<vsg::Device> device, uint32_t queueFamily, 
+                   vsg::ref_ptr<vsg::RenderPass> renderPass, 
                    uint32_t minImageCount, uint32_t imageCount,
-                   VkExtent2D imageSize);
+                   VkExtent2D imageSize, bool useClearAttachments);
         void _uploadFonts();
     };
 

--- a/include/vsgImGui/RenderImGui.h
+++ b/include/vsgImGui/RenderImGui.h
@@ -40,6 +40,11 @@ namespace vsgImGui
     public:
         RenderImGui(const vsg::ref_ptr<vsg::Window>& window, bool useClearAttachments = false);
 
+        RenderImGui(vsg::ref_ptr<vsg::Device> device, uint32_t queueFamily,
+                   vsg::ref_ptr<vsg::RenderPass> renderPass,
+                   uint32_t minImageCount, uint32_t imageCount,
+                   VkExtent2D imageSize);
+
         template<typename... Args>
         RenderImGui(const vsg::ref_ptr<vsg::Window>& window, Args&... args) :
             RenderImGui(window, false)
@@ -80,6 +85,10 @@ namespace vsgImGui
         vsg::ref_ptr<vsg::ClearAttachments> _clearAttachments;
 
         void _init(const vsg::ref_ptr<vsg::Window>& window);
+        void _init(vsg::ref_ptr<vsg::Device> device, uint32_t queueFamily,
+                   vsg::ref_ptr<vsg::RenderPass> renderPass,
+                   uint32_t minImageCount, uint32_t imageCount,
+                   VkExtent2D imageSize);
         void _uploadFonts();
     };
 


### PR DESCRIPTION
Fairly straightforward at the vsgImGui level - New constructor added and _init methods shuffled around to allow construction without the vsg::Window handle.

One extra fix to ensure ImGuiIO::DisplaySize is initialised to something - I assume this is normally set when handling input or otherwise rendering to the window, but when rendering to texture it doesn't get initialised, and can assert inside ImGui.

Tested by a quick example setup, wasn't planning on merging it to vsgExamples but could if needed:
* https://github.com/geefr/vsgExamples/blob/vsgimgui-render-to-texture/examples/ui/vsgimgui_rendertotexture_example/vsgimgui_rendertotexture_example.cpp

![image](https://user-images.githubusercontent.com/11091460/212531404-e0b6260a-09d8-4d6b-aec5-1de3e761764b.png)
