### PR TITLE
Interrogate WantCaptureKeyboard() to ensure that non-ImGui keyboard events get handled by VSG

### DIFF
--- a/src/vsgImGui/SendEventsToImGui.cpp
+++ b/src/vsgImGui/SendEventsToImGui.cpp
@@ -242,49 +242,57 @@ void SendEventsToImGui::_updateModifier(ImGuiIO& io, vsg::KeyModifier& modifier,
 void SendEventsToImGui::apply(vsg::KeyPressEvent& keyPress)
 {
     ImGuiIO& io = ImGui::GetIO();
-    _updateModifier(io, keyPress.keyModifier, true);
-    auto itr = _vsg2imgui.find(keyPress.keyBase);
-    auto imguiKey = ImGuiKey_None;
-    if (itr != _vsg2imgui.end())
-    {
-        imguiKey = itr->second;
-    }
-    else
-    {
-        // This particular VSG key is not handled. If it should be, please raise an issue or a pull request.
-        imguiKey = ImGuiKey_None;
-    }
-    io.AddKeyEvent(imguiKey, true);
 
-    // Irrespective of whether we recognize the vsg key witin _vsg2imgui, if its an ascii character, we add it as an input character.
-    // If other characters should be allowed please raise an issue and pull request.
-    // Adding as an input character on KeyPress allows user to repeat the values until release.
-    if (uint16_t c = keyPress.keyModified; c > 0 && c < 255)
+    if(io.WantCaptureKeyboard)
     {
-        io.AddInputCharacter(c);
+        _updateModifier(io, keyPress.keyModifier, true);
+        auto itr = _vsg2imgui.find(keyPress.keyBase);
+        auto imguiKey = ImGuiKey_None;
+        if (itr != _vsg2imgui.end())
+        {
+            imguiKey = itr->second;
+        }
+        else
+        {
+            // This particular VSG key is not handled. If it should be, please raise an issue or a pull request.
+            imguiKey = ImGuiKey_None;
+        }
+        io.AddKeyEvent(imguiKey, true);
+
+        // Irrespective of whether we recognize the vsg key witin _vsg2imgui, if its an ascii character, we add it as an input character.
+        // If other characters should be allowed please raise an issue and pull request.
+        // Adding as an input character on KeyPress allows user to repeat the values until release.
+        if (uint16_t c = keyPress.keyModified; c > 0 && c < 255)
+        {
+            io.AddInputCharacter(c);
+        }
+        keyPress.handled = true;
     }
-    keyPress.handled = true;
 }
 
 void SendEventsToImGui::apply(vsg::KeyReleaseEvent& keyRelease)
 {
     ImGuiIO& io = ImGui::GetIO();
-    _updateModifier(io, keyRelease.keyModifier, false);
-    auto itr = _vsg2imgui.find(keyRelease.keyBase);
 
-    auto imguiKey = ImGuiKey_None;
-    if (itr != _vsg2imgui.end())
+    if(io.WantCaptureKeyboard)
     {
-        imguiKey = itr->second;
-    }
-    else
-    {
-        // This particular VSG key is not handled. If it should be, please raise an issue or a pull request.
-        imguiKey = ImGuiKey_None;
-    }
+        _updateModifier(io, keyRelease.keyModifier, false);
+        auto itr = _vsg2imgui.find(keyRelease.keyBase);
 
-    io.AddKeyEvent(imguiKey, false);
-    keyRelease.handled = true;
+        auto imguiKey = ImGuiKey_None;
+        if (itr != _vsg2imgui.end())
+        {
+            imguiKey = itr->second;
+        }
+        else
+        {
+            // This particular VSG key is not handled. If it should be, please raise an issue or a pull request.
+            imguiKey = ImGuiKey_None;
+        }
+
+        io.AddKeyEvent(imguiKey, false);
+        keyRelease.handled = true;
+    }
 }
 
 void SendEventsToImGui::apply(vsg::ConfigureWindowEvent& configureWindow)

--- a/src/vsgImGui/SendEventsToImGui.cpp
+++ b/src/vsgImGui/SendEventsToImGui.cpp
@@ -120,6 +120,7 @@ void SendEventsToImGui::_initKeymap()
     _vsg2imgui[vsg::KEY_Insert]        = ImGuiKey_Insert;
     _vsg2imgui[vsg::KEY_Num_Lock]      = ImGuiKey_NumLock;
     _vsg2imgui[vsg::KEY_KP_Enter]      = ImGuiKey_KeypadEnter;
+    // _vsg2imgui[vsg::KEY_KP_Enter]      = ImGuiKey_Enter;
     _vsg2imgui[vsg::KEY_KP_Equal]      = ImGuiKey_KeypadEqual;
     _vsg2imgui[vsg::KEY_KP_Multiply]   = ImGuiKey_KeypadMultiply;
     _vsg2imgui[vsg::KEY_KP_Add]        = ImGuiKey_KeypadAdd;
@@ -274,7 +275,9 @@ void SendEventsToImGui::apply(vsg::KeyReleaseEvent& keyRelease)
 {
     ImGuiIO& io = ImGui::GetIO();
 
-    if(io.WantCaptureKeyboard)
+    // io.WantCaptureKeyboard becomes false when Enter is PRESSED. 
+    // We therefore have to also test for Enter to be RELEASED here to prevent undesirable behaviour when next entering a text edit box
+    if(io.WantCaptureKeyboard || keyRelease.keyBase == vsg::KeySymbol::KEY_Return || keyRelease.keyBase == vsg::KeySymbol::KEY_KP_Enter)
     {
         _updateModifier(io, keyRelease.keyModifier, false);
         auto itr = _vsg2imgui.find(keyRelease.keyBase);


### PR DESCRIPTION
Reinstating io.WantCaptureKeyboard. Without this, all events are handled by ImGui and the regular VSG event handling system won't receive any keyboard events.