### PR TITLE
Don't pass real minImageCount if it is less than 2

### DIFF
--- a/src/vsgImGui/RenderImGui.cpp
+++ b/src/vsgImGui/RenderImGui.cpp
@@ -86,8 +86,9 @@ void RenderImGui::_init(const vsg::ref_ptr<vsg::Window>& window, bool useClearAt
             imageCount,
             capabilities.maxImageCount); // Vulkan spec specifies 0 as being
                                          // unlimited number of images
-
-    _init(device, queueFamily, window->getOrCreateRenderPass(), capabilities.minImageCount, imageCount, window->extent2D(), useClearAttachments);
+    // ImGui doesn't do anything useful with minImageCount and throws an assert if it is less than 2.
+    _init(device, queueFamily, window->getOrCreateRenderPass(), std::max(2u, capabilities.minImageCount),
+          imageCount, window->extent2D(), useClearAttachments);
 }
 
 void RenderImGui::_init(


### PR DESCRIPTION
Some hardware (e.g., AMD Integrated Radeon Graphics) reports capabilities.minImageCount of 1 from the physical device. ImGui throws an assert in Debug mode if the value is less than 2, and for no good reason: it has nothing to do with the functioning of ImGui. It might be used by the ImGui utility functions for opening a window, which we do not care about.

Eventually this should be a bug report against ImGui itself, but I don't know the code well enough to make a pull request.