### PR TITLE
add ImageComponent that creates and draws ImGui images

### DIFF
--- a/include/vsgImGui/ImageComponent.h
+++ b/include/vsgImGui/ImageComponent.h
@@ -1,0 +1,65 @@
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2023 Timothy Moore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+</editor-fold> */
+
+#pragma once
+
+
+// A component that can render an image in Dear ImGui.
+
+#include <vsg/commands/Command.h>
+#include <vsg/core/Inherit.h>
+#include <vsg/app/Window.h>
+
+#include <vsgImGui/Export.h>
+
+#include <vsgImGui/RenderImGui.h>
+
+namespace vsgImGui
+{
+    // This is a subclass of command so that it can be compiled.
+    class VSGIMGUI_DECLSPEC ImageComponent : public vsg::Inherit<vsg::Command, ImageComponent>
+    {
+    public:
+        ImageComponent(vsg::ref_ptr<vsg::Window> window, vsg::ref_ptr<vsg::Data> texData);
+        /**
+         * @brief Call ImGui::Image with the dimensions of the texture.
+         */
+        bool operator()();
+        template<typename... Args>
+        bool operator()(float displayWidth, float displayHeight, Args&&... args)
+        {
+            ImGui::Image(getTextureID(),
+                         ImVec2(displayWidth, displayHeight), args...);
+            return true;
+        }
+        void compile(vsg::Context& context) override;
+        void record(vsg::CommandBuffer& commandBuffer) const override;
+        ImTextureID getTextureID() const;
+        vsg::ref_ptr<vsg::DescriptorSet> descriptorSet;
+        uint32_t height;
+        uint32_t width;
+    protected:
+        vsg::ref_ptr<vsg::Window> _window;
+    };
+}

--- a/include/vsgImGui/RenderImGui.h
+++ b/include/vsgImGui/RenderImGui.h
@@ -32,6 +32,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <vsgImGui/Export.h>
 #include <vsgImGui/imgui.h>
 
+#include <vector>
+
 namespace vsgImGui
 {
 
@@ -65,14 +67,20 @@ namespace vsgImGui
         /// add a GUI rendering component that provides the ImGui calls to render the
         /// required GUI elements.
         void add(const Component& component);
-
+        // add a resource (e.g., an ImageComponent) that will need to
+        void addResource(vsg::ref_ptr<vsg::Command> resource)
+        {
+            _resources.push_back(resource);
+        }
         Components& getComponents() { return _components; }
         const Components& getComponents() const { return _components; }
 
         bool renderComponents() const;
 
+        void compile(vsg::Context& context) override;
         void record(vsg::CommandBuffer& commandBuffer) const override;
-
+    protected:
+        std::vector<vsg::ref_ptr<vsg::Command>> _resources;
     private:
         virtual ~RenderImGui();
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ SET(HEADER_PATH ${VSGIMGUI_SOURCE_DIR}/include/vsgImGui)
 set(HEADERS
     ${HEADER_PATH}/imgui.h
     ${HEADER_PATH}/SendEventsToImGui.h
+    ${HEADER_PATH}/ImageComponent.h
     ${HEADER_PATH}/RenderImGui.h
     imgui/imconfig.h
     imgui/imgui_internal.h
@@ -26,6 +27,7 @@ set(SOURCES
     imgui/imgui_tables.cpp
     imgui/imgui_widgets.cpp
     imgui/backends/imgui_impl_vulkan.cpp
+    vsgImGui/ImageComponent.cpp
     vsgImGui/RenderImGui.cpp
     vsgImGui/SendEventsToImGui.cpp
     imgui/misc/cpp/imgui_stdlib.cpp

--- a/src/vsgImGui/ImageComponent.cpp
+++ b/src/vsgImGui/ImageComponent.cpp
@@ -1,0 +1,89 @@
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2023 Timothy Moore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+</editor-fold> */
+
+#include <vsgImGui/ImageComponent.h>
+
+#include <vsgImGui/RenderImGui.h>
+
+#include <vsg/all.h>
+
+using namespace vsgImGui;
+
+namespace
+{
+    vsg::ref_ptr<vsg::DescriptorSet> makeImageDescriptorSet(vsg::ref_ptr<vsg::Data> texData)
+    {
+    if (!texData) return {};
+    // set up graphics pipeline
+
+    vsg::DescriptorSetLayoutBindings descriptorBindings{
+        {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr} // { binding, descriptorTpe, descriptorCount, stageFlags, pImmutableSamplers}
+    };
+
+    auto descriptorSetLayout = vsg::DescriptorSetLayout::create(descriptorBindings);
+    // create texture image and associated DescriptorSets and binding
+    auto sampler = vsg::Sampler::create();
+    sampler->maxLod = 9.0;      // whatever for now
+    sampler->addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    sampler->addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    sampler->addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    auto texture = vsg::DescriptorImage::create(sampler, texData, 0, 0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
+
+    auto descriptorSet = vsg::DescriptorSet::create(descriptorSetLayout, vsg::Descriptors{texture});
+    return descriptorSet;
+    }
+} // namespace
+
+ImageComponent::ImageComponent(vsg::ref_ptr<vsg::Window> window,
+                               vsg::ref_ptr<vsg::Data> texData)
+    :  height(texData->height()), width(texData->width()), _window(window)
+{
+    descriptorSet = makeImageDescriptorSet(texData);
+}
+
+void ImageComponent::compile(vsg::Context& context)
+{
+    if (_window->getDevice()->deviceID != context.deviceID)
+    {
+        vsg::fatal("ImageComponent can only be used in the Window for which it was created.");
+        return;
+    }
+    descriptorSet->compile(context);
+}
+
+ImTextureID ImageComponent::getTextureID() const
+{
+    return static_cast<ImTextureID>(descriptorSet->vk(_window->getDevice()->deviceID));
+}
+
+bool ImageComponent::operator()()
+{
+    ImGui::Image(getTextureID(), ImVec2(static_cast<float>(width), static_cast<float>(height)));
+    return true;
+}
+
+void ImageComponent::record(vsg::CommandBuffer&) const
+{
+    vsg::fatal("An ImageComponent can't be recorded.");
+}

--- a/src/vsgImGui/RenderImGui.cpp
+++ b/src/vsgImGui/RenderImGui.cpp
@@ -205,6 +205,14 @@ bool RenderImGui::renderComponents() const
     return visibleComponents;
 }
 
+void RenderImGui::compile(vsg::Context& context)
+{
+    for (auto resource : _resources)
+    {
+        resource->compile(context);
+    }
+}
+
 void RenderImGui::record(vsg::CommandBuffer& commandBuffer) const
 {
     bool visibleComponents = renderComponents();


### PR DESCRIPTION
Add a compile() function to RenderImGui that compiles child resources like ImageComponent.

This is similar to the code I wrote for vsgCs. I'm not entirely happy that compilable resources in components need to be added directly to the RenderImGui object. It would be better if RenderImGui traversed its components during compile(), but at the moment the components are subclasses of a VSG class that has a compile() member function. Changing that would require more of an incompatible change than I'm willing to make without some discussion.