### PR TITLE
Let the user create the ImGUI context to control the settings

### DIFF
--- a/src/vsgImGui/RenderImGui.cpp
+++ b/src/vsgImGui/RenderImGui.cpp
@@ -118,8 +118,8 @@ void RenderImGui::_init(
     VkExtent2D imageSize, bool useClearAttachments)
 {
     IMGUI_CHECKVERSION();
-    ImGui::CreateContext();
-    ImPlot::CreateContext();
+    //ImGui::CreateContext();
+    //ImPlot::CreateContext();
 
     VkSampleCountFlagBits samples = VK_SAMPLE_COUNT_1_BIT;
     for (auto& attachment : renderPass->attachments)

--- a/src/vsgImGui/RenderImGui.cpp
+++ b/src/vsgImGui/RenderImGui.cpp
@@ -118,8 +118,17 @@ void RenderImGui::_init(
     VkExtent2D imageSize, bool useClearAttachments)
 {
     IMGUI_CHECKVERSION();
-    //ImGui::CreateContext();
-    //ImPlot::CreateContext();
+    auto imGuiContext = ImGui::GetCurrentContext();
+    if (imGuiContext == nullptr)
+    {
+    	ImGui::CreateContext();
+    }
+    
+    auto imPlotContext = ImPlot::GetCurrentContext();
+    if (imPlotContext == nullptr)
+    {
+    	ImPlot::CreateContext();
+    }
 
     VkSampleCountFlagBits samples = VK_SAMPLE_COUNT_1_BIT;
     for (auto& attachment : renderPass->attachments)


### PR DESCRIPTION
Let the user create the ImGUI context to control the settings before the renderer is initialized.