### PR TITLE
Always pass events to ImGui to solve keyRelease issues

### DIFF
--- a/src/vsgImGui/SendEventsToImGui.cpp
+++ b/src/vsgImGui/SendEventsToImGui.cpp
@@ -266,7 +266,7 @@ void SendEventsToImGui::apply(vsg::KeyPressEvent& keyPress)
     }
 
     // If ImGui was expecting the keyboard event then we mark it as handled
-    if (io.WantCaptureKeyboard) keyPress.handled = true;
+    keyPress.handled = io.WantCaptureKeyboard;
 }
 
 void SendEventsToImGui::apply(vsg::KeyReleaseEvent& keyRelease)
@@ -292,7 +292,7 @@ void SendEventsToImGui::apply(vsg::KeyReleaseEvent& keyRelease)
     io.AddKeyEvent(imguiKey, false);
 
     // If ImGui was expecting the keyboard event then we mark it as handled
-    if (io.WantCaptureKeyboard) keyRelease.handled = true;
+    keyRelease.handled = io.WantCaptureKeyboard;
 }
 
 void SendEventsToImGui::apply(vsg::ConfigureWindowEvent& configureWindow)


### PR DESCRIPTION
This PR always sends keyboard events to ImGui regardless of the state of io.WantCaptureKeyboard. io.WantCaptureKeyboard is used to determine whether the keyboard event has been handled.

These changes are in line with ImGui recommendations and solve the issue of io.WantCaptureKeyboard being false after Enter is pressed (currently handled by special code in SendEventsToImGui::apply(vsg::KeyReleaseEvent& keyRelease) ). It also solves the not-yet-documented issue where the user loses control of dialogs because the Tab key constantly repeats because the Tab KeyRelease event is missed because io.WantCaptureKeyboard becomes false prematurely.

The ImGui FAQ at https://github.com/ocornut/imgui/blob/master/docs/FAQ.md#q-how-can-i-tell-whether-to-dispatch-mousekeyboard-to-dear-imgui-or-my-application stresses that you should always send events to ImGui.

> ![image](https://github.com/vsg-dev/vsgImGui/assets/2024003/de58ad25-0b01-4ae5-a6b2-3d412335c9f8)


The PR also removes the special KeyRelease code (originally added by me) to handle Enter because it is no longer needed.

Tested on Kubuntu with VSG master libraries pulled today. Note that using Tab to navigate through dialogs also requires the following during setup
`    io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard | ImGuiConfigFlags_NavNoCaptureKeyboard;
`