### PR TITLE
Add options to use system dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ project(vsgImGui
     DESCRIPTION "VulkanSceneGraph, ImGui and ImPlot integration library"
     LANGUAGES CXX
 )
+
+option(VSG_IMGUI_USE_SYSTEM_IMGUI "Use system installed ImGui" OFF)
+option(VSG_IMGUI_USE_SYSTEM_IMPLOT "Use system installed ImPlot" OFF)
+
 set(VSGIMGUI_SOVERSION 0)
 SET(VSGIMGUI_RELEASE_CANDIDATE 0)
 
@@ -27,29 +31,43 @@ find_package(vsg 1.0.5)
 vsg_setup_dir_vars()
 vsg_setup_build_vars()
 
-if ( (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/imgui/imgui.h) OR
-     (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/implot/implot.h) )
-    find_package(Git QUIET)
+if(NOT VSG_IMGUI_USE_SYSTEM_IMGUI OR NOT VSG_IMGUI_USE_SYSTEM_IMPLOT)
+    if ( (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/imgui/imgui.h) OR
+        (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/implot/implot.h) )
+        find_package(Git QUIET)
 
-    execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                    RESULT_VARIABLE GIT_SUBMOD_RESULT)
+        execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+                        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                        RESULT_VARIABLE GIT_SUBMOD_RESULT)
 
-    if(NOT GIT_SUBMOD_RESULT EQUAL "0")
-        message(FATAL_ERROR "git submodule update --init --recursive failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
+        if(NOT GIT_SUBMOD_RESULT EQUAL "0")
+            message(FATAL_ERROR "git submodule update --init --recursive failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
+        endif()
     endif()
 endif()
 
-vsg_copy_imgui_headers(
-    FILES
-        ${VSGIMGUI_SOURCE_DIR}/src/imgui/imgui.h
-        ${VSGIMGUI_SOURCE_DIR}/src/imgui/imconfig.h
-        ${VSGIMGUI_SOURCE_DIR}/src/imgui/imgui_internal.h
-        ${VSGIMGUI_SOURCE_DIR}/src/imgui/imstb_textedit.h
-        ${VSGIMGUI_SOURCE_DIR}/src/imgui//misc/cpp/imgui_stdlib.h
-        ${VSGIMGUI_SOURCE_DIR}/src/implot/implot.h
-        ${VSGIMGUI_SOURCE_DIR}/src/implot/implot_internal.h
-)
+if(VSG_IMGUI_USE_SYSTEM_IMGUI)
+    find_package(imgui CONFIG REQUIRED)
+else()
+    vsg_copy_imgui_headers(
+        FILES
+            ${VSGIMGUI_SOURCE_DIR}/src/imgui/imgui.h
+            ${VSGIMGUI_SOURCE_DIR}/src/imgui/imconfig.h
+            ${VSGIMGUI_SOURCE_DIR}/src/imgui/imgui_internal.h
+            ${VSGIMGUI_SOURCE_DIR}/src/imgui/imstb_textedit.h
+            ${VSGIMGUI_SOURCE_DIR}/src/imgui//misc/cpp/imgui_stdlib.h
+    )
+endif()
+
+if(VSG_IMGUI_USE_SYSTEM_IMPLOT)
+    find_package(implot CONFIG REQUIRED)
+else()
+    vsg_copy_imgui_headers(
+        FILES
+            ${VSGIMGUI_SOURCE_DIR}/src/implot/implot.h
+            ${VSGIMGUI_SOURCE_DIR}/src/implot/implot_internal.h
+    )
+endif()
 
 vsg_add_target_clang_format(
     FILES

--- a/include/vsgImGui/RenderImGui.h
+++ b/include/vsgImGui/RenderImGui.h
@@ -31,7 +31,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <vsg/vk/DescriptorPool.h>
 
 #include <vsgImGui/Export.h>
-#include <vsgImGui/imgui.h>
+#include <imgui.h>
 
 namespace vsgImGui
 {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,41 +6,60 @@ set(EXTRA_INCLUDES)
 SET(HEADER_PATH ${VSGIMGUI_SOURCE_DIR}/include/vsgImGui)
 
 set(HEADERS
-    ${HEADER_PATH}/imgui.h
     ${HEADER_PATH}/SendEventsToImGui.h
     ${HEADER_PATH}/RenderImGui.h
     ${HEADER_PATH}/Texture.h
-    imgui/imconfig.h
-    imgui/imgui_internal.h
-    imgui/imstb_rectpack.h
-    imgui/imstb_textedit.h
-    imgui/imstb_truetype.h
-    imgui/misc/cpp/imgui_stdlib.h
-    implot/implot.h
-    implot/implot_internal.h
 )
 
 set(SOURCES
     vsgImGui/RenderImGui.cpp
     vsgImGui/SendEventsToImGui.cpp
     vsgImGui/Texture.cpp
-    imgui/imgui.cpp
-    imgui/imgui_draw.cpp
-    imgui/imgui_tables.cpp
-    imgui/imgui_widgets.cpp
-    imgui/backends/imgui_impl_vulkan.cpp
-    imgui/misc/cpp/imgui_stdlib.cpp
-    implot/implot.cpp
-    implot/implot_items.cpp
 )
+
+if(NOT VSG_IMGUI_USE_SYSTEM_IMGUI)
+    set(HEADERS ${HEADERS}
+        imgui/imgui.h
+        imgui/imconfig.h
+        imgui/imgui_internal.h
+        imgui/imstb_rectpack.h
+        imgui/imstb_textedit.h
+        imgui/imstb_truetype.h
+        imgui/misc/cpp/imgui_stdlib.h
+    )
+
+    set(SOURCES ${SOURCES}
+        imgui/imgui.cpp
+        imgui/imgui_draw.cpp
+        imgui/imgui_tables.cpp
+        imgui/imgui_widgets.cpp
+        imgui/backends/imgui_impl_vulkan.cpp
+        imgui/misc/cpp/imgui_stdlib.cpp
+    )
+endif()
+
+if(NOT VSG_IMGUI_USE_SYSTEM_IMPLOT)
+    set(HEADERS ${HEADERS}
+        implot/implot.h
+        implot/implot_internal.h
+    )
+
+    set(SOURCES ${SOURCES}
+        implot/implot.cpp
+        implot/implot_items.cpp
+    )
+endif()
 
 OPTION(SHOW_DEMO_WINDOW "Toggle the build of the ImGui::ShowDemoWindow(bool*) and ImPlot::ShadowDemoWindow(bool*)" ON)
 
 if (SHOW_DEMO_WINDOW)
-    set(SOURCES ${SOURCES}
-        imgui/imgui_demo.cpp
-        implot/implot_demo.cpp
-    )
+    if(NOT VSG_IMGUI_USE_SYSTEM_IMGUI)
+        set(HEADERS ${HEADERS} imgui/imgui_demo.cpp)
+    endif()
+
+    if(NOT VSG_IMGUI_USE_SYSTEM_IMPLOT)
+        set(SOURCES ${SOURCES} implot/implot_demo.cpp)
+    endif()
 else()
     set(SOURCES ${SOURCES}
         vsgImGui/fallback_demo.cpp
@@ -69,6 +88,11 @@ target_include_directories(vsgImGui PUBLIC
     $<INSTALL_INTERFACE:include>
     ${EXTRA_INCLUDES}
 )
+if(NOT VSG_IMGUI_USE_SYSTEM_IMGUI)
+    target_include_directories(vsgImGui PRIVATE
+        $<BUILD_INTERFACE:${VSGIMGUI_SOURCE_DIR}/src/imgui/backends>
+    )
+endif()
 
 target_link_libraries(vsgImGui
     PUBLIC
@@ -76,6 +100,14 @@ target_link_libraries(vsgImGui
     PRIVATE
         ${EXTRA_LIBRARIES}
 )
+
+if(VSG_IMGUI_USE_SYSTEM_IMGUI)
+    target_link_libraries(vsgImGui PUBLIC imgui::imgui)
+endif()
+
+if(VSG_IMGUI_USE_SYSTEM_IMPLOT)
+    target_link_libraries(vsgImGui PUBLIC implot::implot)
+endif()
 
 install(TARGETS vsgImGui ${INSTALL_TARGETS_DEFAULT_FLAGS})
 

--- a/src/vsgImGui/RenderImGui.cpp
+++ b/src/vsgImGui/RenderImGui.cpp
@@ -22,9 +22,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 </editor-fold> */
 
 #include <vsgImGui/RenderImGui.h>
-#include <vsgImGui/implot.h>
+#include <implot.h>
 
-#include "../imgui/backends/imgui_impl_vulkan.h"
+#include <imgui_impl_vulkan.h>
 
 #include <vsg/io/Logger.h>
 #include <vsg/vk/State.h>

--- a/src/vsgImGui/SendEventsToImGui.cpp
+++ b/src/vsgImGui/SendEventsToImGui.cpp
@@ -22,7 +22,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 </editor-fold> */
 
 #include <vsgImGui/SendEventsToImGui.h>
-#include <vsgImGui/imgui.h>
+#include <imgui.h>
 
 #include <vsg/ui/KeyEvent.h>
 #include <vsg/ui/PointerEvent.h>


### PR DESCRIPTION
This PR addresses the issue https://github.com/vsg-dev/vsgImGui/issues/72.

I have tested it locally and confirmed that it builds successfully with the options both `ON` and `OFF`.