### PR TITLE
Fix in-tree warnings when building a library using vsgImGui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ local.properties
 
 *imgui.ini
 /CMakeSettings.json
+/.vscode

--- a/include/vsgImGui/Export.h
+++ b/include/vsgImGui/Export.h
@@ -35,6 +35,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #    define VSGIMGUI_DECLSPEC
 #endif
 
+// Fix in-tree build warning C4005 - macro redefinition
+#if defined(IMGUI_API) || defined(IMPLOT_API)
+#    undef IMGUI_API
+#    undef IMPLOT_API
+#endif
+
 #define IMGUI_API VSGIMGUI_DECLSPEC
 #define IMPLOT_API VSGIMGUI_DECLSPEC
 


### PR DESCRIPTION
Again a microfix that doesn't really need a ticket or extra explanation.  It just a fact that pops up as soon as you use vsgImGui in an in-tree build environment.

Problem at hand: in-tree compile of vsgImGui raises C4005 "macro redefinition" warnings

Reason: multiple TUs need to use the same header, thus it happens in user code that ImGui-macros are already defined when including `vsgImGui/RenderImGui.h`.

Fix: undefine macros if they're already defined prior to redefinition.